### PR TITLE
Fix MSVC 2017 support

### DIFF
--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -32,9 +32,15 @@
 
 // Compiler detection:
 
-#define variant_CPP11_OR_GREATER  ( __cplusplus >= 201103L )
-#define variant_CPP14_OR_GREATER  ( __cplusplus >= 201402L )
-#define variant_CPP17_OR_GREATER  ( __cplusplus >= 201703L )
+#ifdef _MSVC_LANG
+# define variant_MSVC_LANG  _MSVC_LANG
+#else
+# define variant_MSVC_LANG  0
+#endif
+
+#define variant_CPP11_OR_GREATER  ( __cplusplus >= 201103L || variant_MSVC_LANG >= 201103L )
+#define variant_CPP14_OR_GREATER  ( __cplusplus >= 201402L || variant_MSVC_LANG >= 201703L )
+#define variant_CPP17_OR_GREATER  ( __cplusplus >= 201703L || variant_MSVC_LANG >= 201703L )
 
 // use C++17 std::variant if available:
 

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -93,6 +93,9 @@ namespace nonstd {
     using std::operator>;
     using std::operator>=;
     using std::swap;
+
+    constexpr auto variant_npos = std::variant_npos;
+
 }
 
 #else // C++17 std::variant


### PR DESCRIPTION
Hi,

There are few problems when using MSVC 2017 that supports `std::variant`.
First one is incorrect detection of supported features.
I copied your change from optional-lite: https://github.com/martinmoene/optional-lite/commit/1cded319c771a68f8fc06f4ec4ac64075fcac343

Second problem is missing `variant_npos` definition.
Looks like MSVC 2017 supports inline variables, but I'm not using it since I have no way to check other compilers.

Hope, changes make sense. Thank you
