### PR TITLE
Identical types support for >= C++11 (fixes #40)

### DIFF
--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -25,10 +25,6 @@
 #define variant_VARIANT_NONSTD   1
 #define variant_VARIANT_STD      2
 
-#if !defined( variant_CONFIG_SELECT_VARIANT )
-# define variant_CONFIG_SELECT_VARIANT  ( variant_HAVE_STD_VARIANT ? variant_VARIANT_STD : variant_VARIANT_NONSTD )
-#endif
-
 #ifndef  variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO
 # define variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO  0
 #endif
@@ -75,6 +71,10 @@
 # endif
 #else
 # define  variant_HAVE_STD_VARIANT  0
+#endif
+
+#if !defined( variant_CONFIG_SELECT_VARIANT )
+# define variant_CONFIG_SELECT_VARIANT  ( variant_HAVE_STD_VARIANT ? variant_VARIANT_STD : variant_VARIANT_NONSTD )
 #endif
 
 #define  variant_USES_STD_VARIANT  ( (variant_CONFIG_SELECT_VARIANT == variant_VARIANT_STD) || ((variant_CONFIG_SELECT_VARIANT == variant_VARIANT_DEFAULT) && variant_HAVE_STD_VARIANT) )

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -387,24 +387,6 @@ namespace nonstd {
 # include <tr1/type_traits>
 #endif
 
-// Method enabling
-
-#if variant_CPP11_OR_GREATER
-
-#define variant_REQUIRES_0(...) \
-    template< bool B = (__VA_ARGS__), typename std::enable_if<B, int>::type = 0 >
-
-#define variant_REQUIRES_T(...) \
-    , typename std::enable_if< (__VA_ARGS__), int >::type = 0
-
-#define variant_REQUIRES_R(R, ...) \
-    typename std::enable_if< (__VA_ARGS__), R>::type
-
-#define variant_REQUIRES_A(...) \
-    , typename std::enable_if< (__VA_ARGS__), void*>::type = nullptr
-
-#endif
-
 //
 // variant:
 //
@@ -472,7 +454,56 @@ struct conditional< false, Then, Else > { typedef Else type; };
 
 #endif // variant_HAVE_CONDITIONAL
 
+#if variant_HAVE_TYPE_TRAITS || variant_HAVE_TR1_TYPE_TRAITS
+
+using std::enable_if;
+using std::is_same;
+
+#else
+
+template< bool B, class T = void >
+struct enable_if {
+};
+
+template< class T >
+struct enable_if< true, T > {
+  typedef T type;
+};
+
+template< class T, class U >
+struct is_same {
+  enum V { value = 0 } ;
+};
+
+template< class T >
+struct is_same< T, T > {
+  enum V { value = 1 } ;
+};
+
+#endif // variant_HAVE_TYPE_TRAITS
+
 } // namespace std11
+
+// Method enabling
+
+#if variant_CPP11_OR_GREATER
+
+#define variant_REQUIRES_T(...) \
+    , typename std::enable_if< (__VA_ARGS__), int >::type = 0
+
+#define variant_REQUIRES_R(R, ...) \
+    typename std::enable_if< (__VA_ARGS__), R>::type
+
+#define variant_REQUIRES_A(...) \
+    , typename std::enable_if< (__VA_ARGS__), void*>::type = nullptr
+
+#endif // variant_CPP11_OR_GREATER
+
+#define variant_REQUIRES_0(...) \
+    template< bool B = (__VA_ARGS__), typename std11::enable_if<B, int>::type = 0 >
+
+#define variant_REQUIRES_B(...) \
+    , bool B = (__VA_ARGS__), typename std11::enable_if<B, int>::type = 0
 
 /// type traits C++17:
 
@@ -741,6 +772,26 @@ template< class Head, class Tail, std::size_t i >
 struct typelist_type_at< typelist<Head, Tail>, i >
 {
     typedef typename typelist_type_at<Tail, i - 1>::type type;
+};
+
+// typelist type is unique:
+
+template< class List, std::size_t CmpIndex, std::size_t LastChecked = typelist_size<List>::value >
+struct typelist_type_is_unique
+{
+private:
+  typedef typename typelist_type_at<List, CmpIndex>::type CmpType;
+  typedef typename typelist_type_at<List, LastChecked - 1>::type CurType;
+
+public:
+  enum V { value = ((CmpIndex == (LastChecked - 1)) | !std11::is_same<CmpType, CurType>::value)
+    && typelist_type_is_unique<List, CmpIndex, LastChecked - 1>::value } ;
+};
+
+template< class List, std::size_t CmpIndex >
+struct typelist_type_is_unique< List, CmpIndex, 0 >
+{
+  enum V { value = 1 } ;
 };
 
 #if variant_CONFIG_MAX_ALIGN_HACK
@@ -1209,45 +1260,186 @@ class variant
 
 public:
     // 19.7.3.1 Constructors
-    
-    variant() : type_index( 0 ) { new( ptr() ) T0(); }
 
+    variant() : type_index( 0 ) { new( ptr() ) T0(); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+#endif
     variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+#endif
     variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+#endif
     variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+#endif
     variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+#endif
     variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+#endif
     variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+#endif
     variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+#endif
     variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+#endif
     variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+#endif
     variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+#endif
     variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+#endif
     variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+#endif
     variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+#endif
     variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+#endif
     variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
+    
+#if variant_CPP11_OR_GREATER
+    template < nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+#endif
     variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
     
 
 #if variant_CPP11_OR_GREATER
-    variant( T0 && t0 ) : type_index( 0 ) { new( ptr() ) T0( std::move(t0) ); }
-    variant( T1 && t1 ) : type_index( 1 ) { new( ptr() ) T1( std::move(t1) ); }
-    variant( T2 && t2 ) : type_index( 2 ) { new( ptr() ) T2( std::move(t2) ); }
-    variant( T3 && t3 ) : type_index( 3 ) { new( ptr() ) T3( std::move(t3) ); }
-    variant( T4 && t4 ) : type_index( 4 ) { new( ptr() ) T4( std::move(t4) ); }
-    variant( T5 && t5 ) : type_index( 5 ) { new( ptr() ) T5( std::move(t5) ); }
-    variant( T6 && t6 ) : type_index( 6 ) { new( ptr() ) T6( std::move(t6) ); }
-    variant( T7 && t7 ) : type_index( 7 ) { new( ptr() ) T7( std::move(t7) ); }
-    variant( T8 && t8 ) : type_index( 8 ) { new( ptr() ) T8( std::move(t8) ); }
-    variant( T9 && t9 ) : type_index( 9 ) { new( ptr() ) T9( std::move(t9) ); }
-    variant( T10 && t10 ) : type_index( 10 ) { new( ptr() ) T10( std::move(t10) ); }
-    variant( T11 && t11 ) : type_index( 11 ) { new( ptr() ) T11( std::move(t11) ); }
-    variant( T12 && t12 ) : type_index( 12 ) { new( ptr() ) T12( std::move(t12) ); }
-    variant( T13 && t13 ) : type_index( 13 ) { new( ptr() ) T13( std::move(t13) ); }
-    variant( T14 && t14 ) : type_index( 14 ) { new( ptr() ) T14( std::move(t14) ); }
-    variant( T15 && t15 ) : type_index( 15 ) { new( ptr() ) T15( std::move(t15) ); }
-    
+    template < nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+    variant( T0 && t0 )
+        : type_index( 0 ) { new( ptr() ) T0( std::move(t0) ); }
+
+    template < nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+    variant( T1 && t1 )
+        : type_index( 1 ) { new( ptr() ) T1( std::move(t1) ); }
+
+    template < nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+    variant( T2 && t2 )
+        : type_index( 2 ) { new( ptr() ) T2( std::move(t2) ); }
+
+    template < nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+    variant( T3 && t3 )
+        : type_index( 3 ) { new( ptr() ) T3( std::move(t3) ); }
+
+    template < nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+    variant( T4 && t4 )
+        : type_index( 4 ) { new( ptr() ) T4( std::move(t4) ); }
+
+    template < nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+    variant( T5 && t5 )
+        : type_index( 5 ) { new( ptr() ) T5( std::move(t5) ); }
+
+    template < nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+    variant( T6 && t6 )
+        : type_index( 6 ) { new( ptr() ) T6( std::move(t6) ); }
+
+    template < nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+    variant( T7 && t7 )
+        : type_index( 7 ) { new( ptr() ) T7( std::move(t7) ); }
+
+    template < nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+    variant( T8 && t8 )
+        : type_index( 8 ) { new( ptr() ) T8( std::move(t8) ); }
+
+    template < nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+    variant( T9 && t9 )
+        : type_index( 9 ) { new( ptr() ) T9( std::move(t9) ); }
+
+    template < nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+    variant( T10 && t10 )
+        : type_index( 10 ) { new( ptr() ) T10( std::move(t10) ); }
+
+    template < nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+    variant( T11 && t11 )
+        : type_index( 11 ) { new( ptr() ) T11( std::move(t11) ); }
+
+    template < nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+    variant( T12 && t12 )
+        : type_index( 12 ) { new( ptr() ) T12( std::move(t12) ); }
+
+    template < nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+    variant( T13 && t13 )
+        : type_index( 13 ) { new( ptr() ) T13( std::move(t13) ); }
+
+    template < nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+    variant( T14 && t14 )
+        : type_index( 14 ) { new( ptr() ) T14( std::move(t14) ); }
+
+    template < nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+    variant( T15 && t15 )
+        : type_index( 15 ) { new( ptr() ) T15( std::move(t15) ); }
 #endif
 
     variant(variant const & other)
@@ -1322,7 +1514,7 @@ public:
 #endif // variant_CPP11_OR_GREATER
 
     // 19.7.3.2 Destructor
-    
+
     ~variant()
     {
         if ( ! valueless_by_exception() )
@@ -1332,7 +1524,7 @@ public:
     }
 
     // 19.7.3.3 Assignment
-    
+
     variant & operator=( variant const & other )
     {
         return copy_assign( other );
@@ -1361,43 +1553,167 @@ public:
         return move_assign( std::move( other ) );
     }
 
+    template <nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
     variant & operator=( T0 &&      t0 ) { return assign_value<0>( std::move( t0 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
     variant & operator=( T1 &&      t1 ) { return assign_value<1>( std::move( t1 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
     variant & operator=( T2 &&      t2 ) { return assign_value<2>( std::move( t2 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
     variant & operator=( T3 &&      t3 ) { return assign_value<3>( std::move( t3 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
     variant & operator=( T4 &&      t4 ) { return assign_value<4>( std::move( t4 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
     variant & operator=( T5 &&      t5 ) { return assign_value<5>( std::move( t5 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
     variant & operator=( T6 &&      t6 ) { return assign_value<6>( std::move( t6 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
     variant & operator=( T7 &&      t7 ) { return assign_value<7>( std::move( t7 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
     variant & operator=( T8 &&      t8 ) { return assign_value<8>( std::move( t8 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
     variant & operator=( T9 &&      t9 ) { return assign_value<9>( std::move( t9 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
     variant & operator=( T10 &&      t10 ) { return assign_value<10>( std::move( t10 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
     variant & operator=( T11 &&      t11 ) { return assign_value<11>( std::move( t11 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
     variant & operator=( T12 &&      t12 ) { return assign_value<12>( std::move( t12 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
     variant & operator=( T13 &&      t13 ) { return assign_value<13>( std::move( t13 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
     variant & operator=( T14 &&      t14 ) { return assign_value<14>( std::move( t14 ) ); }
+
+    template <nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
     variant & operator=( T15 &&      t15 ) { return assign_value<15>( std::move( t15 ) ); }
-    
 
 #endif
 
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+#endif
     variant & operator=( T0 const & t0 ) { return assign_value<0>( t0 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+#endif
     variant & operator=( T1 const & t1 ) { return assign_value<1>( t1 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+#endif
     variant & operator=( T2 const & t2 ) { return assign_value<2>( t2 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+#endif
     variant & operator=( T3 const & t3 ) { return assign_value<3>( t3 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+#endif
     variant & operator=( T4 const & t4 ) { return assign_value<4>( t4 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+#endif
     variant & operator=( T5 const & t5 ) { return assign_value<5>( t5 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+#endif
     variant & operator=( T6 const & t6 ) { return assign_value<6>( t6 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+#endif
     variant & operator=( T7 const & t7 ) { return assign_value<7>( t7 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+#endif
     variant & operator=( T8 const & t8 ) { return assign_value<8>( t8 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+#endif
     variant & operator=( T9 const & t9 ) { return assign_value<9>( t9 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+#endif
     variant & operator=( T10 const & t10 ) { return assign_value<10>( t10 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+#endif
     variant & operator=( T11 const & t11 ) { return assign_value<11>( t11 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+#endif
     variant & operator=( T12 const & t12 ) { return assign_value<12>( t12 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+#endif
     variant & operator=( T13 const & t13 ) { return assign_value<13>( t13 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+#endif
     variant & operator=( T14 const & t14 ) { return assign_value<14>( t14 ); }
+
+    #if variant_CPP11_OR_GREATER
+    template <nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+#endif
     variant & operator=( T15 const & t15 ) { return assign_value<15>( t15 ); }
-    
 
     std::size_t index() const
     {
@@ -1405,7 +1721,7 @@ public:
     }
 
     // 19.7.3.4 Modifiers
-    
+
 #if variant_CPP11_OR_GREATER
     template< class T, class... Args
         variant_REQUIRES_T( std::is_constructible< T, Args...>::value )
@@ -1450,14 +1766,14 @@ public:
 #endif // variant_CPP11_OR_GREATER
 
     // 19.7.3.5 Value status
-    
+
     bool valueless_by_exception() const
     {
         return type_index == variant_npos_internal();
     }
 
     // 19.7.3.6 Swap
-    
+
     void swap( variant & other )
 #if variant_CPP11_OR_GREATER
         noexcept(
@@ -1884,7 +2200,7 @@ template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, 
 >
 inline void swap(
     variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & a,
-    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & b ) 
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & b )
 #if variant_CPP11_OR_GREATER
     noexcept( noexcept( a.swap( b ) ) )
 #endif

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -727,7 +727,7 @@ template<> struct typelist_size< nulltype > { enum V { value = 0 } ; };
 template< class Head, class Tail >
 struct typelist_size< typelist<Head, Tail> >
 {
-    enum V { value = typelist_size<Head>::value + typelist_size<Tail>::value };
+    enum V { value = size_t(typelist_size<Head>::value) + size_t(typelist_size<Tail>::value) };
 };
 
 // typelist index of type:

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -794,6 +794,11 @@ struct typelist_type_is_unique< List, CmpIndex, 0 >
   enum V { value = 1 } ;
 };
 
+template< class List, class T >
+struct typelist_contains_unique_type : typelist_type_is_unique< List, typelist_index_of< List, T >::value >
+{
+};
+
 #if variant_CONFIG_MAX_ALIGN_HACK
 
 // Max align, use most restricted type for alignment:
@@ -1725,6 +1730,7 @@ public:
 #if variant_CPP11_OR_GREATER
     template< class T, class... Args
         variant_REQUIRES_T( std::is_constructible< T, Args...>::value )
+        variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )
     >
     T& emplace( Args&&... args )
     {
@@ -1737,6 +1743,7 @@ public:
 
     template< class T, class U, class... Args
         variant_REQUIRES_T( std::is_constructible< T, std::initializer_list<U>&, Args...>::value )
+        variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )
     >
     T& emplace( std::initializer_list<U> il, Args&&... args )
     {

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -167,6 +167,25 @@ inline in_place_t in_place_index( detail::in_place_index_tag<K> = detail::in_pla
 #endif // variant_CPP17_OR_GREATER
 #endif // nonstd_lite_HAVE_IN_PLACE_TYPES
 
+// in_place_index-like disambiguation tag identical for all C++ versions:
+
+namespace nonstd {
+namespace variants {
+namespace detail {
+
+template< std::size_t K >
+struct index_tag_t {};
+
+template< std::size_t K >
+inline void index_tag ( index_tag_t<K> = index_tag_t<K>() ) { }
+
+#define variant_index_tag_t(K)  void(&)( nonstd::variants::detail::index_tag_t<K> )
+#define variant_index_tag(K)    nonstd::variants::detail::index_tag<K>
+
+} // namespace detail
+} // namespace variants
+} // namespace nonstd
+
 //
 // Use C++17 std::variant:
 //
@@ -1278,179 +1297,179 @@ public:
     variant() : type_index( 0 ) { new( ptr() ) T0(); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
 #endif
     variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
 #endif
     variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
 #endif
     variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
 #endif
     variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
 #endif
     variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
 #endif
     variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
 #endif
     variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
 #endif
     variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
 #endif
     variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
 #endif
     variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
 #endif
     variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
 #endif
     variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
 #endif
     variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
 #endif
     variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
 #endif
     variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
     
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
 #endif
     variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
     
 
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
     variant( T0 && t0 )
         : type_index( 0 ) { new( ptr() ) T0( std::move(t0) ); }
 
-    template < nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
     variant( T1 && t1 )
         : type_index( 1 ) { new( ptr() ) T1( std::move(t1) ); }
 
-    template < nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
     variant( T2 && t2 )
         : type_index( 2 ) { new( ptr() ) T2( std::move(t2) ); }
 
-    template < nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
     variant( T3 && t3 )
         : type_index( 3 ) { new( ptr() ) T3( std::move(t3) ); }
 
-    template < nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
     variant( T4 && t4 )
         : type_index( 4 ) { new( ptr() ) T4( std::move(t4) ); }
 
-    template < nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
     variant( T5 && t5 )
         : type_index( 5 ) { new( ptr() ) T5( std::move(t5) ); }
 
-    template < nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
     variant( T6 && t6 )
         : type_index( 6 ) { new( ptr() ) T6( std::move(t6) ); }
 
-    template < nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
     variant( T7 && t7 )
         : type_index( 7 ) { new( ptr() ) T7( std::move(t7) ); }
 
-    template < nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
     variant( T8 && t8 )
         : type_index( 8 ) { new( ptr() ) T8( std::move(t8) ); }
 
-    template < nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
     variant( T9 && t9 )
         : type_index( 9 ) { new( ptr() ) T9( std::move(t9) ); }
 
-    template < nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
     variant( T10 && t10 )
         : type_index( 10 ) { new( ptr() ) T10( std::move(t10) ); }
 
-    template < nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
     variant( T11 && t11 )
         : type_index( 11 ) { new( ptr() ) T11( std::move(t11) ); }
 
-    template < nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
     variant( T12 && t12 )
         : type_index( 12 ) { new( ptr() ) T12( std::move(t12) ); }
 
-    template < nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
     variant( T13 && t13 )
         : type_index( 13 ) { new( ptr() ) T13( std::move(t13) ); }
 
-    template < nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
     variant( T14 && t14 )
         : type_index( 14 ) { new( ptr() ) T14( std::move(t14) ); }
 
-    template < nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
     variant( T15 && t15 )
         : type_index( 15 ) { new( ptr() ) T15( std::move(t15) ); }
@@ -1567,164 +1586,164 @@ public:
         return move_assign( std::move( other ) );
     }
 
-    template <nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
     variant & operator=( T0 &&      t0 ) { return assign_value<0>( std::move( t0 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
     variant & operator=( T1 &&      t1 ) { return assign_value<1>( std::move( t1 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
     variant & operator=( T2 &&      t2 ) { return assign_value<2>( std::move( t2 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
     variant & operator=( T3 &&      t3 ) { return assign_value<3>( std::move( t3 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
     variant & operator=( T4 &&      t4 ) { return assign_value<4>( std::move( t4 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
     variant & operator=( T5 &&      t5 ) { return assign_value<5>( std::move( t5 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
     variant & operator=( T6 &&      t6 ) { return assign_value<6>( std::move( t6 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
     variant & operator=( T7 &&      t7 ) { return assign_value<7>( std::move( t7 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
     variant & operator=( T8 &&      t8 ) { return assign_value<8>( std::move( t8 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
     variant & operator=( T9 &&      t9 ) { return assign_value<9>( std::move( t9 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
     variant & operator=( T10 &&      t10 ) { return assign_value<10>( std::move( t10 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
     variant & operator=( T11 &&      t11 ) { return assign_value<11>( std::move( t11 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
     variant & operator=( T12 &&      t12 ) { return assign_value<12>( std::move( t12 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
     variant & operator=( T13 &&      t13 ) { return assign_value<13>( std::move( t13 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
     variant & operator=( T14 &&      t14 ) { return assign_value<14>( std::move( t14 ) ); }
 
-    template <nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
     variant & operator=( T15 &&      t15 ) { return assign_value<15>( std::move( t15 ) ); }
 
 #endif
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 0 ) = nonstd_lite_in_place_index( 0 )
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
 #endif
     variant & operator=( T0 const & t0 ) { return assign_value<0>( t0 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 1 ) = nonstd_lite_in_place_index( 1 )
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
 #endif
     variant & operator=( T1 const & t1 ) { return assign_value<1>( t1 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 2 ) = nonstd_lite_in_place_index( 2 )
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
 #endif
     variant & operator=( T2 const & t2 ) { return assign_value<2>( t2 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 3 ) = nonstd_lite_in_place_index( 3 )
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
 #endif
     variant & operator=( T3 const & t3 ) { return assign_value<3>( t3 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 4 ) = nonstd_lite_in_place_index( 4 )
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
 #endif
     variant & operator=( T4 const & t4 ) { return assign_value<4>( t4 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 5 ) = nonstd_lite_in_place_index( 5 )
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
 #endif
     variant & operator=( T5 const & t5 ) { return assign_value<5>( t5 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 6 ) = nonstd_lite_in_place_index( 6 )
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
 #endif
     variant & operator=( T6 const & t6 ) { return assign_value<6>( t6 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 7 ) = nonstd_lite_in_place_index( 7 )
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
 #endif
     variant & operator=( T7 const & t7 ) { return assign_value<7>( t7 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 8 ) = nonstd_lite_in_place_index( 8 )
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
 #endif
     variant & operator=( T8 const & t8 ) { return assign_value<8>( t8 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 9 ) = nonstd_lite_in_place_index( 9 )
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
 #endif
     variant & operator=( T9 const & t9 ) { return assign_value<9>( t9 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 10 ) = nonstd_lite_in_place_index( 10 )
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
 #endif
     variant & operator=( T10 const & t10 ) { return assign_value<10>( t10 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 11 ) = nonstd_lite_in_place_index( 11 )
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
 #endif
     variant & operator=( T11 const & t11 ) { return assign_value<11>( t11 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 12 ) = nonstd_lite_in_place_index( 12 )
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
 #endif
     variant & operator=( T12 const & t12 ) { return assign_value<12>( t12 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 13 ) = nonstd_lite_in_place_index( 13 )
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
 #endif
     variant & operator=( T13 const & t13 ) { return assign_value<13>( t13 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 14 ) = nonstd_lite_in_place_index( 14 )
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
 #endif
     variant & operator=( T14 const & t14 ) { return assign_value<14>( t14 ); }
 
     #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( 15 ) = nonstd_lite_in_place_index( 15 )
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
 #endif
     variant & operator=( T15 const & t15 ) { return assign_value<15>( t15 ); }

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -335,6 +335,8 @@ namespace nonstd {
 #define variant_HAVE_REMOVE_CV          variant_CPP11_120
 #define variant_HAVE_STD_ADD_POINTER    variant_CPP11_90
 #define variant_HAVE_TYPE_TRAITS        variant_CPP11_90
+#define variant_HAVE_ENABLE_IF          variant_CPP11_90
+#define variant_HAVE_IS_SAME            variant_CPP11_90
 
 #define variant_HAVE_TR1_TYPE_TRAITS    (!! variant_COMPILER_GNUC_VERSION )
 #define variant_HAVE_TR1_ADD_POINTER    (!! variant_COMPILER_GNUC_VERSION )
@@ -454,10 +456,9 @@ struct conditional< false, Then, Else > { typedef Else type; };
 
 #endif // variant_HAVE_CONDITIONAL
 
-#if variant_HAVE_TYPE_TRAITS || variant_HAVE_TR1_TYPE_TRAITS
+#if variant_HAVE_ENABLE_IF
 
 using std::enable_if;
-using std::is_same;
 
 #else
 
@@ -470,6 +471,14 @@ struct enable_if< true, T > {
   typedef T type;
 };
 
+#endif // variant_HAVE_ENABLE_IF
+
+#if variant_HAVE_IS_SAME
+
+using std::is_same;
+
+#else
+
 template< class T, class U >
 struct is_same {
   enum V { value = 0 } ;
@@ -480,7 +489,7 @@ struct is_same< T, T > {
   enum V { value = 1 } ;
 };
 
-#endif // variant_HAVE_TYPE_TRAITS
+#endif // variant_HAVE_IS_SAME
 
 } // namespace std11
 

--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -482,13 +482,10 @@ using std::enable_if;
 #else
 
 template< bool B, class T = void >
-struct enable_if {
-};
+struct enable_if { };
 
 template< class T >
-struct enable_if< true, T > {
-  typedef T type;
-};
+struct enable_if< true, T > { typedef T type; };
 
 #endif // variant_HAVE_ENABLE_IF
 
@@ -500,12 +497,12 @@ using std::is_same;
 
 template< class T, class U >
 struct is_same {
-  enum V { value = 0 } ;
+    enum V { value = 0 } ;
 };
 
 template< class T >
 struct is_same< T, T > {
-  enum V { value = 1 } ;
+    enum V { value = 1 } ;
 };
 
 #endif // variant_HAVE_IS_SAME
@@ -808,18 +805,18 @@ template< class List, std::size_t CmpIndex, std::size_t LastChecked = typelist_s
 struct typelist_type_is_unique
 {
 private:
-  typedef typename typelist_type_at<List, CmpIndex>::type CmpType;
-  typedef typename typelist_type_at<List, LastChecked - 1>::type CurType;
+    typedef typename typelist_type_at<List, CmpIndex>::type cmp_type;
+    typedef typename typelist_type_at<List, LastChecked - 1>::type cur_type;
 
 public:
-  enum V { value = ((CmpIndex == (LastChecked - 1)) | !std11::is_same<CmpType, CurType>::value)
-    && typelist_type_is_unique<List, CmpIndex, LastChecked - 1>::value } ;
+    enum V { value = ((CmpIndex == (LastChecked - 1)) | !std11::is_same<cmp_type, cur_type>::value)
+        && typelist_type_is_unique<List, CmpIndex, LastChecked - 1>::value } ;
 };
 
 template< class List, std::size_t CmpIndex >
 struct typelist_type_is_unique< List, CmpIndex, 0 >
 {
-  enum V { value = 1 } ;
+    enum V { value = 1 } ;
 };
 
 template< class List, class T >
@@ -1295,182 +1292,171 @@ public:
     // 19.7.3.1 Constructors
 
     variant() : type_index( 0 ) { new( ptr() ) T0(); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
-#endif
-    variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
-#endif
-    variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
-#endif
-    variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
-#endif
-    variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
-#endif
-    variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
-#endif
-    variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
-#endif
-    variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
-#endif
-    variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
-#endif
-    variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
-#endif
-    variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
-#endif
-    variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
-#endif
-    variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
-#endif
-    variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
-#endif
-    variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
-#endif
-    variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
-    
-#if variant_CPP11_OR_GREATER
-    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
-#endif
-    variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
-    
 
 #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+    variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
+
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+    variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
+
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+    variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
+
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+    variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
+
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+    variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
+
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+    variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
+
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+    variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
+
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+    variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
+
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+    variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
+
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+    variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
+
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+    variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
+
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+    variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
+
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+    variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
+
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+    variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
+
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+    variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
+
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+    variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
+
+#else
+
+    variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
+    variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
+    variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
+    variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
+    variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
+    variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
+    variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
+    variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
+    variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
+    variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
+    variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
+    variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
+    variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
+    variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
+    variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
+    variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
+    
+#endif
+
+#if variant_CPP11_OR_GREATER
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
     variant( T0 && t0 )
         : type_index( 0 ) { new( ptr() ) T0( std::move(t0) ); }
 
     template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
     variant( T1 && t1 )
         : type_index( 1 ) { new( ptr() ) T1( std::move(t1) ); }
 
     template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
     variant( T2 && t2 )
         : type_index( 2 ) { new( ptr() ) T2( std::move(t2) ); }
 
     template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
     variant( T3 && t3 )
         : type_index( 3 ) { new( ptr() ) T3( std::move(t3) ); }
 
     template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
     variant( T4 && t4 )
         : type_index( 4 ) { new( ptr() ) T4( std::move(t4) ); }
 
     template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
     variant( T5 && t5 )
         : type_index( 5 ) { new( ptr() ) T5( std::move(t5) ); }
 
     template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
     variant( T6 && t6 )
         : type_index( 6 ) { new( ptr() ) T6( std::move(t6) ); }
 
     template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
     variant( T7 && t7 )
         : type_index( 7 ) { new( ptr() ) T7( std::move(t7) ); }
 
     template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
     variant( T8 && t8 )
         : type_index( 8 ) { new( ptr() ) T8( std::move(t8) ); }
 
     template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
     variant( T9 && t9 )
         : type_index( 9 ) { new( ptr() ) T9( std::move(t9) ); }
 
     template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
     variant( T10 && t10 )
         : type_index( 10 ) { new( ptr() ) T10( std::move(t10) ); }
 
     template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
     variant( T11 && t11 )
         : type_index( 11 ) { new( ptr() ) T11( std::move(t11) ); }
 
     template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
     variant( T12 && t12 )
         : type_index( 12 ) { new( ptr() ) T12( std::move(t12) ); }
 
     template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
     variant( T13 && t13 )
         : type_index( 13 ) { new( ptr() ) T13( std::move(t13) ); }
 
     template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
     variant( T14 && t14 )
         : type_index( 14 ) { new( ptr() ) T14( std::move(t14) ); }
 
     template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
-      variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
     variant( T15 && t15 )
         : type_index( 15 ) { new( ptr() ) T15( std::move(t15) ); }
 #endif
@@ -1652,101 +1638,92 @@ public:
 
 #endif
 
-    #if variant_CPP11_OR_GREATER
+#if variant_CPP11_OR_GREATER
+
     template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
-#endif
     variant & operator=( T0 const & t0 ) { return assign_value<0>( t0 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
-#endif
     variant & operator=( T1 const & t1 ) { return assign_value<1>( t1 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
-#endif
     variant & operator=( T2 const & t2 ) { return assign_value<2>( t2 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
-#endif
     variant & operator=( T3 const & t3 ) { return assign_value<3>( t3 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
-#endif
     variant & operator=( T4 const & t4 ) { return assign_value<4>( t4 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
-#endif
     variant & operator=( T5 const & t5 ) { return assign_value<5>( t5 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
-#endif
     variant & operator=( T6 const & t6 ) { return assign_value<6>( t6 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
-#endif
     variant & operator=( T7 const & t7 ) { return assign_value<7>( t7 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
-#endif
     variant & operator=( T8 const & t8 ) { return assign_value<8>( t8 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
-#endif
     variant & operator=( T9 const & t9 ) { return assign_value<9>( t9 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
-#endif
     variant & operator=( T10 const & t10 ) { return assign_value<10>( t10 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
-#endif
     variant & operator=( T11 const & t11 ) { return assign_value<11>( t11 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
-#endif
     variant & operator=( T12 const & t12 ) { return assign_value<12>( t12 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
-#endif
     variant & operator=( T13 const & t13 ) { return assign_value<13>( t13 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
-#endif
     variant & operator=( T14 const & t14 ) { return assign_value<14>( t14 ); }
 
-    #if variant_CPP11_OR_GREATER
     template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
-#endif
     variant & operator=( T15 const & t15 ) { return assign_value<15>( t15 ); }
+
+#else
+
+    variant & operator=( T0 const & t0 ) { return assign_value<0>( t0 ); }
+    variant & operator=( T1 const & t1 ) { return assign_value<1>( t1 ); }
+    variant & operator=( T2 const & t2 ) { return assign_value<2>( t2 ); }
+    variant & operator=( T3 const & t3 ) { return assign_value<3>( t3 ); }
+    variant & operator=( T4 const & t4 ) { return assign_value<4>( t4 ); }
+    variant & operator=( T5 const & t5 ) { return assign_value<5>( t5 ); }
+    variant & operator=( T6 const & t6 ) { return assign_value<6>( t6 ); }
+    variant & operator=( T7 const & t7 ) { return assign_value<7>( t7 ); }
+    variant & operator=( T8 const & t8 ) { return assign_value<8>( t8 ); }
+    variant & operator=( T9 const & t9 ) { return assign_value<9>( t9 ); }
+    variant & operator=( T10 const & t10 ) { return assign_value<10>( t10 ); }
+    variant & operator=( T11 const & t11 ) { return assign_value<11>( t11 ); }
+    variant & operator=( T12 const & t12 ) { return assign_value<12>( t12 ); }
+    variant & operator=( T13 const & t13 ) { return assign_value<13>( t13 ); }
+    variant & operator=( T14 const & t14 ) { return assign_value<14>( t14 ); }
+    variant & operator=( T15 const & t15 ) { return assign_value<15>( t15 ); }
+    
+#endif
 
     std::size_t index() const
     {
@@ -1756,6 +1733,7 @@ public:
     // 19.7.3.4 Modifiers
 
 #if variant_CPP11_OR_GREATER
+
     template< class T, class... Args
         variant_REQUIRES_T( std::is_constructible< T, Args...>::value )
         variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )

--- a/template/variant.hpp
+++ b/template/variant.hpp
@@ -25,10 +25,6 @@
 #define variant_VARIANT_NONSTD   1
 #define variant_VARIANT_STD      2
 
-#if !defined( variant_CONFIG_SELECT_VARIANT )
-# define variant_CONFIG_SELECT_VARIANT  ( variant_HAVE_STD_VARIANT ? variant_VARIANT_STD : variant_VARIANT_NONSTD )
-#endif
-
 #ifndef  variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO
 # define variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO  0
 #endif
@@ -75,6 +71,10 @@
 # endif
 #else
 # define  variant_HAVE_STD_VARIANT  0
+#endif
+
+#if !defined( variant_CONFIG_SELECT_VARIANT )
+# define variant_CONFIG_SELECT_VARIANT  ( variant_HAVE_STD_VARIANT ? variant_VARIANT_STD : variant_VARIANT_NONSTD )
 #endif
 
 #define  variant_USES_STD_VARIANT  ( (variant_CONFIG_SELECT_VARIANT == variant_VARIANT_STD) || ((variant_CONFIG_SELECT_VARIANT == variant_VARIANT_DEFAULT) && variant_HAVE_STD_VARIANT) )

--- a/template/variant.hpp
+++ b/template/variant.hpp
@@ -686,7 +686,7 @@ template<> struct typelist_size< nulltype > { enum V { value = 0 } ; };
 template< class Head, class Tail >
 struct typelist_size< typelist<Head, Tail> >
 {
-    enum V { value = typelist_size<Head>::value + typelist_size<Tail>::value };
+    enum V { value = size_t(typelist_size<Head>::value) + size_t(typelist_size<Tail>::value) };
 };
 
 // typelist index of type:

--- a/template/variant.hpp
+++ b/template/variant.hpp
@@ -167,6 +167,25 @@ inline in_place_t in_place_index( detail::in_place_index_tag<K> = detail::in_pla
 #endif // variant_CPP17_OR_GREATER
 #endif // nonstd_lite_HAVE_IN_PLACE_TYPES
 
+// in_place_index-like disambiguation tag identical for all C++ versions:
+
+namespace nonstd {
+namespace variants {
+namespace detail {
+
+template< std::size_t K >
+struct index_tag_t {};
+
+template< std::size_t K >
+inline void index_tag ( index_tag_t<K> = index_tag_t<K>() ) { }
+
+#define variant_index_tag_t(K)  void(&)( nonstd::variants::detail::index_tag_t<K> )
+#define variant_index_tag(K)    nonstd::variants::detail::index_tag<K>
+
+} // namespace detail
+} // namespace variants
+} // namespace nonstd
+
 //
 // Use C++17 std::variant:
 //
@@ -1143,7 +1162,7 @@ public:
 
     {%- for n in range(NumParams) %}
 #if variant_CPP11_OR_GREATER
-    template < nonstd_lite_in_place_index_t( {{n}} ) = nonstd_lite_in_place_index( {{n}} )
+    template < variant_index_tag_t( {{n}} ) = variant_index_tag( {{n}} )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, {{n}} >::value) >
 #endif
     variant( T{{n}} const & t{{n}} ) : type_index( {{n}} ) { new( ptr() ) T{{n}}( t{{n}} ); }
@@ -1151,7 +1170,7 @@ public:
 
 #if variant_CPP11_OR_GREATER
     {% for n in range(NumParams) -%}
-    template < nonstd_lite_in_place_index_t( {{n}} ) = nonstd_lite_in_place_index( {{n}} )
+    template < variant_index_tag_t( {{n}} ) = variant_index_tag( {{n}} )
       variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, {{n}} >::value) >
     variant( T{{n}} && t{{n}} )
         : type_index( {{n}} ) { new( ptr() ) T{{n}}( std::move(t{{n}}) ); }
@@ -1247,7 +1266,7 @@ public:
     }
 
     {% for n in range(NumParams) -%}
-    template <nonstd_lite_in_place_index_t( {{n}} ) = nonstd_lite_in_place_index( {{n}} )
+    template < variant_index_tag_t( {{n}} ) = variant_index_tag( {{n}} )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, {{n}} >::value) >
     variant & operator=( T{{n}} &&      t{{n}} ) { return assign_value<{{n}}>( std::move( t{{n}} ) ); }
     {%- if not loop.last %}
@@ -1259,7 +1278,7 @@ public:
 
     {% for n in range(NumParams) -%}
 #if variant_CPP11_OR_GREATER
-    template <nonstd_lite_in_place_index_t( {{n}} ) = nonstd_lite_in_place_index( {{n}} )
+    template < variant_index_tag_t( {{n}} ) = variant_index_tag( {{n}} )
         variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, {{n}} >::value) >
 #endif
     variant & operator=( T{{n}} const & t{{n}} ) { return assign_value<{{n}}>( t{{n}} ); }

--- a/template/variant.hpp
+++ b/template/variant.hpp
@@ -335,6 +335,8 @@ namespace nonstd {
 #define variant_HAVE_REMOVE_CV          variant_CPP11_120
 #define variant_HAVE_STD_ADD_POINTER    variant_CPP11_90
 #define variant_HAVE_TYPE_TRAITS        variant_CPP11_90
+#define variant_HAVE_ENABLE_IF          variant_CPP11_90
+#define variant_HAVE_IS_SAME            variant_CPP11_90
 
 #define variant_HAVE_TR1_TYPE_TRAITS    (!! variant_COMPILER_GNUC_VERSION )
 #define variant_HAVE_TR1_ADD_POINTER    (!! variant_COMPILER_GNUC_VERSION )
@@ -454,10 +456,9 @@ struct conditional< false, Then, Else > { typedef Else type; };
 
 #endif // variant_HAVE_CONDITIONAL
 
-#if variant_HAVE_TYPE_TRAITS || variant_HAVE_TR1_TYPE_TRAITS
+#if variant_HAVE_ENABLE_IF
 
 using std::enable_if;
-using std::is_same;
 
 #else
 
@@ -470,6 +471,14 @@ struct enable_if< true, T > {
   typedef T type;
 };
 
+#endif // variant_HAVE_ENABLE_IF
+
+#if variant_HAVE_IS_SAME
+
+using std::is_same;
+
+#else
+
 template< class T, class U >
 struct is_same {
   enum V { value = 0 } ;
@@ -480,7 +489,7 @@ struct is_same< T, T > {
   enum V { value = 1 } ;
 };
 
-#endif // variant_HAVE_TYPE_TRAITS
+#endif // variant_HAVE_IS_SAME
 
 } // namespace std11
 

--- a/template/variant.hpp
+++ b/template/variant.hpp
@@ -753,6 +753,11 @@ struct typelist_type_is_unique< List, CmpIndex, 0 >
   enum V { value = 1 } ;
 };
 
+template< class List, class T >
+struct typelist_contains_unique_type : typelist_type_is_unique< List, typelist_index_of< List, T >::value >
+{
+};
+
 #if variant_CONFIG_MAX_ALIGN_HACK
 
 // Max align, use most restricted type for alignment:
@@ -1264,6 +1269,7 @@ public:
 #if variant_CPP11_OR_GREATER
     template< class T, class... Args
         variant_REQUIRES_T( std::is_constructible< T, Args...>::value )
+        variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )
     >
     T& emplace( Args&&... args )
     {
@@ -1276,6 +1282,7 @@ public:
 
     template< class T, class U, class... Args
         variant_REQUIRES_T( std::is_constructible< T, std::initializer_list<U>&, Args...>::value )
+        variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )
     >
     T& emplace( std::initializer_list<U> il, Args&&... args )
     {

--- a/test/variant-main.t.cpp
+++ b/test/variant-main.t.cpp
@@ -36,8 +36,10 @@ CASE( "variant configuration" "[.variant][.config]" )
     variant_PRESENT( variant_VARIANT_STD );
     variant_PRESENT( variant_CONFIG_SELECT_VARIANT );
     variant_PRESENT( variant_CONFIG_NO_EXCEPTIONS );
+#if !variant_USES_STD_VARIANT
     variant_PRESENT( variant_CONFIG_MAX_TYPE_COUNT );
     variant_PRESENT( variant_CONFIG_MAX_VISITOR_ARG_COUNT );
+#endif
     variant_PRESENT( variant_CPLUSPLUS );
 }
 

--- a/test/variant-main.t.hpp
+++ b/test/variant-main.t.hpp
@@ -31,8 +31,8 @@
 
 namespace lest {
 
-template< class...  Types >
-inline std::ostream & operator<<( std::ostream & os, nonstd::variant<Types...> const & v )
+template< class Head, class...  Types >
+inline std::ostream & operator<<( std::ostream & os, nonstd::variant<Head, Types...> const & v )
 {
     return os << "[variant:?]";
 }

--- a/test/variant.t.cpp
+++ b/test/variant.t.cpp
@@ -187,6 +187,7 @@ CASE( "variant: Disallows non-default constructible as first type" )
 CASE( "variant: Allows non-default constructible as second and later type (first: int)" )
 {
     variant<int, NoDefaultConstruct> var;
+    (void) var;
 
     EXPECT( true );
 }
@@ -194,6 +195,7 @@ CASE( "variant: Allows non-default constructible as second and later type (first
 CASE( "variant: Allows non-default constructible as second and later type (first: monostate)" )
 {
     variant<monostate, NoDefaultConstruct> var;
+    (void) var;
 
     EXPECT( true );
 }
@@ -201,6 +203,7 @@ CASE( "variant: Allows non-default constructible as second and later type (first
 CASE( "variant: Allows multiple identical types" )
 {
     variant<monostate, int, int> var;
+    (void) var;
 
     EXPECT( true );
 }
@@ -1185,7 +1188,7 @@ struct RVRefTestVisitor
     template< typename U >
     std::string operator()( U && ) const
     {
-        static_assert( std::is_const<U>::value, "Wrong branch!" );
+        //static_assert( std::is_const<U>::value, "Wrong branch!" );
         return ">>> Broken branch! <<<";
     }
 };
@@ -1352,6 +1355,7 @@ CASE( "variant: Allows to swap variants, different index (non-member)" )
 CASE( "monostate: Allows to make variant default-constructible" )
 {
     variant<monostate, NoDefaultConstruct> var;
+    (void) var;
 
     EXPECT( true );
 }

--- a/test/variant.t.cpp
+++ b/test/variant.t.cpp
@@ -1190,10 +1190,17 @@ struct RVRefTestVisitor
     }
 
     template< typename U >
-    std::string operator()( U && ) const
+    std::string operator()( U && val) const
     {
-        //static_assert( std::is_const<U>::value, "Wrong branch!" );
+#if variant_USES_STD_VARIANT
+        std::ostringstream os;
+        os << val;
+        return os.str();
+#else
+        static_assert( std::is_const<U>::value, "Wrong branch!" );
+        (void) val;
         return ">>> Broken branch! <<<";
+#endif
     }
 };
 

--- a/test/variant.t.cpp
+++ b/test/variant.t.cpp
@@ -891,6 +891,19 @@ CASE( "variant: Allows to copy-emplace element based on type (C++11)" )
 #endif
 }
 
+CASE( "variant: Disallows to copy-emplace non-unique element type on type (C++11)" )
+{
+#if variant_CPP11_OR_GREATER
+    variant<monostate, int, int> var;
+    //var.emplace<int>(7);
+    (void) var;
+
+    EXPECT( true );
+#else
+    EXPECT( !!"variant: multiple identical types are not available (no C++11)" );
+#endif
+}
+
 CASE( "variant: Allows to move-emplace element based on type (C++11)" )
 {
 #if variant_CPP11_OR_GREATER

--- a/test/variant.t.cpp
+++ b/test/variant.t.cpp
@@ -200,12 +200,16 @@ CASE( "variant: Allows non-default constructible as second and later type (first
     EXPECT( true );
 }
 
-CASE( "variant: Allows multiple identical types" )
+CASE( "variant: Allows multiple identical types (C++11)" )
 {
+#if variant_CPP11_OR_GREATER
     variant<monostate, int, int> var;
     (void) var;
 
     EXPECT( true );
+#else
+    EXPECT( !!"variant: move-construction is not available (no C++11)" );
+#endif
 }
 
 CASE( "variant: Allows to default-construct variant" )

--- a/test/variant.t.cpp
+++ b/test/variant.t.cpp
@@ -12,7 +12,7 @@
 using namespace nonstd;
 
 namespace {
-    
+
 using lest::to_string;
 
 // ensure comparison of pointers for lest:
@@ -194,6 +194,13 @@ CASE( "variant: Allows non-default constructible as second and later type (first
 CASE( "variant: Allows non-default constructible as second and later type (first: monostate)" )
 {
     variant<monostate, NoDefaultConstruct> var;
+
+    EXPECT( true );
+}
+
+CASE( "variant: Allows multiple identical types" )
+{
+    variant<monostate, int, int> var;
 
     EXPECT( true );
 }
@@ -1071,7 +1078,11 @@ struct GenericVisitor1
     }
 };
 
+#if variant_USES_STD_VARIANT
+CASE( "variant: Allows to visit contents (args: 1)" )
+#else
 CASE( "variant: Allows to visit contents (args: 1; configured max args: " + to_string(variant_CONFIG_MAX_VISITOR_ARG_COUNT) + ")" )
+#endif
 {
     typedef variant< int, std::string > var_t;
     var_t vi = 7;
@@ -1098,7 +1109,11 @@ struct GenericVisitor2
     }
 };
 
+#if variant_USES_STD_VARIANT
+CASE( "variant: Allows to visit contents (args: 2)" )
+#else
 CASE( "variant: Allows to visit contents (args: 2; configured max args: " + to_string(variant_CONFIG_MAX_VISITOR_ARG_COUNT) + ")" )
+#endif
 {
     typedef variant< int, std::string > var_t;
     var_t vi = 7;
@@ -1124,7 +1139,11 @@ struct GenericVisitor3
     }
 };
 
+#if variant_USES_STD_VARIANT
+CASE( "variant: Allows to visit contents (args: 3)" )
+#else
 CASE( "variant: Allows to visit contents (args: 3; configured max args: " + to_string(variant_CONFIG_MAX_VISITOR_ARG_COUNT) + ")" )
+#endif
 {
     typedef variant< int, std::string, double > var_t;
     var_t vi = 7;
@@ -1201,7 +1220,11 @@ struct Unwrapper
 
 #endif
 
+#if variant_USES_STD_VARIANT
+CASE( "variant: Allows to visit contents, rvalue reference (args: 1)" )
+#else
 CASE( "variant: Allows to visit contents, rvalue reference (args: 1; configured max args: " + to_string(variant_CONFIG_MAX_VISITOR_ARG_COUNT) + ")" )
+#endif
 {
 #if variant_CPP14_OR_GREATER
     typedef std::shared_ptr< std::string > string_ptr_t;
@@ -1355,7 +1378,11 @@ namespace {
     struct t8{};
 }
 
+#if variant_USES_STD_VARIANT
+CASE( "variant_size<>: Allows to obtain number of element types" )
+#else
 CASE( "variant_size<>: Allows to obtain number of element types (configured max types: " + to_string(variant_CONFIG_MAX_TYPE_COUNT) + ")" )
+#endif
 {
     typedef variant<t1> var1;
     typedef variant<t1, t2> var2;
@@ -1376,7 +1403,11 @@ CASE( "variant_size<>: Allows to obtain number of element types (configured max 
 //  EXPECT( 8u == to_size_t( variant_size<var8>::value ) );
 }
 
+#if variant_USES_STD_VARIANT
+CASE( "variant_size_v<>: Allows to obtain number of element types (C++14)" )
+#else
 CASE( "variant_size_v<>: Allows to obtain number of element types (C++14; configured max types: " + to_string(variant_CONFIG_MAX_TYPE_COUNT) + ")" )
+#endif
 {
 #if variant_CPP14_OR_GREATER
     typedef variant<t1> var1;
@@ -1401,7 +1432,11 @@ CASE( "variant_size_v<>: Allows to obtain number of element types (C++14; config
 #endif
 }
 
+#if variant_USES_STD_VARIANT
+CASE( "variant_size_V(): Allows to obtain number of element types (non-standard: macro)" )
+#else
 CASE( "variant_size_V(): Allows to obtain number of element types (non-standard: macro; configured max types: " + to_string(variant_CONFIG_MAX_TYPE_COUNT) + ")" )
+#endif
 {
     typedef variant<t1> var1;
     typedef variant<t1, t2> var2;

--- a/test/variant.t.cpp
+++ b/test/variant.t.cpp
@@ -208,7 +208,7 @@ CASE( "variant: Allows multiple identical types (C++11)" )
 
     EXPECT( true );
 #else
-    EXPECT( !!"variant: move-construction is not available (no C++11)" );
+    EXPECT( !!"variant: multiple identical types are not available (no C++11)" );
 #endif
 }
 


### PR DESCRIPTION
This branch contains changes required to support multiple identical types (e.g. `nonstd::variant<nonstd::monostate, int, int>`), and accompanying tests. I've tried keeping the code style of my changes identical to what was already there.

Note that I couldn't get this working for C++98. The reason being that there's no support for non-type template parameter default arguments for function templates. I use a defaulted function reference template argument to disambiguate between otherwise identical functions, such as constructors for `T1` and `T2` for a type `nonstd::variant<nonstd::monostate, int, int>`.

For the regular constructors (as well as copy constructor) this lack of support for default template arguments can be worked around by disambiguating with a defaulted function argument instead. Unfortunately, this is not possible for the assignment operator, which can only have a single argument.

Hence the lack of C++98 support. Maybe there's another way to do this, but I couldn't think of any. Just in case there's a simple way to add this support, I've already written all required SFINAE helper structs in a C++98-compatible way.

I've also made a couple of changes/fixes to the ordering of some defines, as well as to the tests. It seems that by default `std::variant` was never pulled in, even if C++17 was available. That's now fixed, as well some test code that started failing as a result of this (see individual commits). The tests for all C++ versions now compile and pass.

If you don't like having the "multiple identical types" + "test fixes" changes in a single pull request, just let me know. Then I'll try and split them up properly.

Feel free to let me know if there's anything that I overlooked or that I should have done differently!