### PR TITLE
Fix failing Clang builds on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [11, 12]
+        include:
+          - version: 11
+            os: 'ubuntu-22.04'
+          - version: 12
+            os: 'ubuntu-22.04'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +65,7 @@ jobs:
         env:
           CXX: clang-${{ matrix.version }}
         run: cmake -S . -B build
-          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_CXX_COMPILER=clang++-${{ matrix.version }}
           -D CMAKE_BUILD_TYPE:STRING=Release
           -D ${{ env.PROJECT }}_OPT_SELECT_NONSTD=ON
           -D ${{ env.PROJECT }}_OPT_BUILD_TESTS=ON


### PR DESCRIPTION
A while ago the `ubuntu-latest` image of GitHub Actions moved from Ubuntu 22.04 to Ubuntu 24.04. See <https://github.com/actions/runner-images/issues/10636> for more information on that change.
However, Ubuntu 24.04 does not have packages for Clang 11 and 12 anymore, thus the Clang jobs failed when they tried to install the corresponding compilers. Therefore, the workflow is changed to use `ubuntu-22.04` instead of `ubuntu-latest`.


_Note:_ This could basically be a one line change, just changing `runs-on: ubuntu-latest` to `runs-on: ubuntu-22.04`.  But if you want to run tests on newer Clang versions, too, then some of them might require Ubuntu 24.04, and in that case this form is easier to extend. For example, one could add the following lines to the job matrix to test more versions:
```yaml
          - version: 13
            os: ubuntu-22.04
          - version: 14
            os: ubuntu-24.04
          - version: 16
            os: ubuntu-24.04
          - version: 18
            os: ubuntu-24.04
```