### PR TITLE
Updated variant index tag definitions for compatibility with clang 

### DIFF
--- a/include/nonstd/variant.hpp
+++ b/include/nonstd/variant.hpp
@@ -205,8 +205,8 @@ struct index_tag_t {};
 template< std::size_t K >
 inline void index_tag ( index_tag_t<K> = index_tag_t<K>() ) { }
 
-#define variant_index_tag_t(K)  void(&)( nonstd::variants::detail::index_tag_t<K> )
-#define variant_index_tag(K)    nonstd::variants::detail::index_tag<K>
+#define variant_index_tag_t(K)  nonstd::variants::detail::index_tag_t<K>*
+#define variant_index_tag(K)    nullptr
 
 } // namespace detail
 } // namespace variants

--- a/template/variant.hpp
+++ b/template/variant.hpp
@@ -197,8 +197,8 @@ struct index_tag_t {};
 template< std::size_t K >
 inline void index_tag ( index_tag_t<K> = index_tag_t<K>() ) { }
 
-#define variant_index_tag_t(K)  void(&)( nonstd::variants::detail::index_tag_t<K> )
-#define variant_index_tag(K)    nonstd::variants::detail::index_tag<K>
+#define variant_index_tag_t(K)  nonstd::variants::detail::index_tag_t<K>*
+#define variant_index_tag(K)    nullptr
 
 } // namespace detail
 } // namespace variants

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,8 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang" )
     set( OPTIONS     -Wall -Wextra -Wconversion -Wsign-conversion -Wno-missing-braces -fno-elide-constructors )
     set( DEFINITIONS ${DEFCMN} )
 
+    set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0" )
+
     # GNU: available -std flags depends on version
     if( CMAKE_CXX_COMPILER_ID MATCHES "GNU" )
         message( STATUS "Matched: GNU")


### PR DESCRIPTION
- Replaced the non-type template parameter with a pointer, which should resolve the reference issue with Clang.
- Fixed unit tests failing with the latest versions of GCC and Clang \[**edit** MM: with **std**::variant\].