### PR TITLE
Fix include path for Windows in lest_cpp03.hpp 

### DIFF
--- a/test/lest/lest_cpp03.hpp
+++ b/test/lest/lest_cpp03.hpp
@@ -66,7 +66,7 @@
 #if lest_FEATURE_TIME
 # if lest_PLATFORM_IS_WINDOWS
 #  include <iomanip>
-#  include <Windows.h>
+#  include <windows.h>
 # else
 #  include <iomanip>
 #  include <sys/time.h>


### PR DESCRIPTION
During cross-compilation with mingw64 on Ubuntu, it appears that file paths are all lowercase. 
The proposal is to make this consistent by using lowercase paths. This shouldn’t affect builds on Windows machines, but it will enable cross-compilation with mingw as well.
The same issue exists for all utilities in the *-lite except for `expected-lite`